### PR TITLE
Remove hardcoded cdn.rawgit.com URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ browser: uglify
 test: browser mocha
 
 uglify:
-	$(UGLIFYJS) uri.js --mangle --preamble $(BANNER) --source-map uri.min.js.map --source-map-url http://cdn.rawgit.com/lil-js/uri/$(VERSION)/uri.min.js.map > uri.min.js
+	$(UGLIFYJS) uri.js --mangle --preamble $(BANNER) --source-map uri.min.js.map > uri.min.js
 
 mocha:
 	$(MOCHA) --reporter spec --ui bdd


### PR DESCRIPTION
By default, the source-map-url will be the same as source-map. When lil-uri is loaded from cdn.rawgit.com, this will resolve to the correct relative source map file, but when it is hosted elsewhere, it will load the source map from there and not cdn.rawgit.com